### PR TITLE
Change voidDock's input to .yaml format

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,26 +60,25 @@ pip3 install vina
 
 ## Step 5: Create Config File
 
-Create a Python script for the configuration file, e.g., `config.py`. Fill in the required paths:
-```python
-def inputs():
-    protDir = "path/to/receptor/pdb/files"
-    ligandDir = "path/to/receptor/pdb/files"
-    outDir = "path/to/desired/output/files"
-    mglToolsDir = "/home/{username}/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs"
-    util24Dir = "/home/{username}/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs/AutoDockTools/Utilities24"
-    ligandOrdersCsv = "path/to/ligands_for_binding.csv"
-
-    return protDir, ligandDir, outDir, mglToolsDir, util24Dir, ligandOrdersCsv
+Create a YAML script for the configuration file, e.g., `config.yaml`. Fill in the required paths:
+```
+dockingTargetsInfo: 
+  protDir: "/home/{username}/voidDock/receptors"
+  ligandDir: "/home/{username}/voidDock/ligands"
+  outDir: "/home/{username}/voidDock/outputs"
+  ligandOrdersCsv: "/home/{username}/voidDock/docking_commands.csv"
+toolInfo:
+  mglToolsDir: "/home/{username}/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs"
+  util24Dir: "/home/{username}/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs/AutoDockTools/Utilities24"
 ```
 
-**Note:** Replace `{username}` and update file paths accordingly in the above commands. Make sure to adjust permissions and paths based on your system configuration.
+**Note:** Replace `{username}` and update file paths accordingly in the above commands. Make sure to adjust permissions and paths based on your system configuration. Do not change the structure of the file, aka 'dockingTargetsInfo' and 'toolINfo' is needed.
 
 ## Step 6: Run voidDock
 Run the voidDock script with the provided configuration file:
 
 ```bash
-python voidDock.py --config config.py
+python voidDock.py --config config.yaml
 ```
 
 happy voidDocking!

--- a/config.yaml
+++ b/config.yaml
@@ -4,12 +4,12 @@
 # outDir - location to save output to
 # ligandOrdersCsv - csv file containing a list of [proteinID,ligandID] to dock
 dockingTargetsInfo: 
-  protDir: "/home/mchrnwsk/voidDock/receptors1"
-  ligandDir: "/home/mchrnwsk/voidDock/ligands1"
-  outDir: "/home/mchrnwsk/voidDock/outputs1"
-  ligandOrdersCsv: "/home/mchrnwsk/voidDock/docking_commands1.csv"
+  protDir: "/home/{username}/voidDock/receptors"
+  ligandDir: "/home/{username}/voidDock/ligands"
+  outDir: "/home/{username}/voidDock/outputs"
+  ligandOrdersCsv: "/home/{username}/voidDock/docking_commands.csv"
 
 # paths to MGLTools utilities
 toolInfo:
-  mglToolsDir: "/home/mchrnwsk/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs"
-  util24Dir: "/home/mchrnwsk/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs/AutoDockTools/Utilities24"
+  mglToolsDir: "/home/{username}/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs"
+  util24Dir: "/home/{username}/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs/AutoDockTools/Utilities24"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,15 @@
+# paths to targets to dock
+# protDir - directory containing the protein(s)
+# ligandDir - directory containing the ligand(s)
+# outDir - location to save output to
+# ligandOrdersCsv - csv file containing a list of [proteinID,ligandID] to dock
+dockingTargetsInfo: 
+  protDir: "/home/mchrnwsk/voidDock/receptors1"
+  ligandDir: "/home/mchrnwsk/voidDock/ligands1"
+  outDir: "/home/mchrnwsk/voidDock/outputs1"
+  ligandOrdersCsv: "/home/mchrnwsk/voidDock/docking_commands1.csv"
+
+# paths to MGLTools utilities
+toolInfo:
+  mglToolsDir: "/home/mchrnwsk/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs"
+  util24Dir: "/home/mchrnwsk/bin/mgltools_x86_64Linux2_1.5.7/MGLToolsPckgs/AutoDockTools/Utilities24"

--- a/voidDock.py
+++ b/voidDock.py
@@ -5,7 +5,7 @@ import os.path as p
 import sys
 import argpass
 import multiprocessing as mp
-
+import yaml
 ## inport util scripts
 from util_voidDock import *
 #########################################################################################################################
@@ -16,7 +16,12 @@ def read_inputs():
     parser.add_argument("--config")
     args = parser.parse_args()
     configName=args.config
-    configName = p.splitext(configName)[0]
+#    configName = p.splitext(configName)[0]
+
+    ## Read config.yaml into a dictionary
+    with open(configName,"r") as yamlFile:
+        configName = yaml.safe_load(yamlFile) 
+    return configName
 
     # add config to PYTHONPATH
     cwd = os.getcwd()
@@ -34,7 +39,15 @@ def read_inputs():
 
 #########################################################################################################################
 def main():
-    protDir, ligandDir, outDir, mglToolsDir, util24Dir, ligandOrdersCsv = read_inputs()
+#    protDir, ligandDir, outDir, mglToolsDir, util24Dir, ligandOrdersCsv = read_inputs()
+
+    configName = read_inputs()
+    protDir = configName["dockingTargetsInfo"]["protDir"]
+    ligandDir = configName["dockingTargetsInfo"]["ligandDir"]
+    outDir = configName["dockingTargetsInfo"]["outDir"]
+    mglToolsDir = configName["toolInfo"]["mglToolsDir"]
+    util24Dir = configName["toolInfo"]["util24Dir"]
+    ligandOrdersCsv = configName["dockingTargetsInfo"]["ligandOrdersCsv"]
 
     # make outDir
     os.makedirs(outDir,exist_ok=True)    


### PR DESCRIPTION
voidDock uses YAML file as input.
Includes example config.yaml file.
Updates README to reflect the changes.